### PR TITLE
Fixed files node model, use passed entity values rather than state values

### DIFF
--- a/component/files/model/entity/node.php
+++ b/component/files/model/entity/node.php
@@ -170,6 +170,10 @@ class ModelEntityNode extends Library\ModelEntityAbstract
     {
         parent::setProperty($name, $value, $modified);
 
+        if($name == 'container'){
+            $this->_container = null; //Clear cached container
+        }
+
         if (in_array($name, array('container', 'folder', 'name'))) {
             $this->setAdapter();
         }

--- a/component/files/model/nodes.php
+++ b/component/files/model/nodes.php
@@ -36,9 +36,9 @@ class ModelNodes extends ModelAbstract
         $entity = parent::_actionCreate($context);
 
         $entity->setProperties(array(
-            'container' => $context->state->container,
-            'folder'    => $context->state->folder,
-            'name'      => $context->state->name
+            'container' => $context->entity->container,
+            'folder'    => $context->entity->folder,
+            'name'      => $context->entity->name
         ));
 
         return $entity;

--- a/component/files/model/nodes.php
+++ b/component/files/model/nodes.php
@@ -36,9 +36,9 @@ class ModelNodes extends ModelAbstract
         $entity = parent::_actionCreate($context);
 
         $entity->setProperties(array(
-            'container' => $context->entity->container,
-            'folder'    => $context->entity->folder,
-            'name'      => $context->entity->name
+            'container' => $context->getState()->container,
+            'folder'    => $context->getEntity()->folder,
+            'name'      => $context->getEntity()->name
         ));
 
         return $entity;


### PR DESCRIPTION
This appears to be a bug, when uploading a file, ControllerBehaviorAttachable::109 passes the file data via the context.

ModelAbstract->create() passes the file data (array) to an "entity" property on a new context

ModelNodes->_actionCreate receives the context as an argument, currently looks in the state property, rather than the entity property.