### PR TITLE
Backtraces raising error due to undefined index.

### DIFF
--- a/component/application/view/error/templates/default_backtrace.html.php
+++ b/component/application/view/error/templates/default_backtrace.html.php
@@ -25,7 +25,7 @@
         <? if( isset( $trace[$i]['class'])) : ?>
         <td><?= $trace[$i]['class'].$trace[$i]['type'].$trace[$i]['function'].'()' ?></td>
         <? else : ?>
-        <td><?= $trace[$i]['function'].'()' ?></td>
+        <td><?= isset($trace[$i]['function']) ? $trace[$i]['function'].'()' : '' ?></td>
         <? endif; ?>
 
         <? if( isset( $trace[$i]['file'])) : ?>


### PR DESCRIPTION
Sometimes an item in the backtrace won't have a function index, eg

    array (size=4)
      'file' => string '/library/template/engine/nooku.php' (length=34)
      'line' => int 351
      'params' => 
        array (size=0)
          empty
      'include_filename' => string '/tmp/buffer54b6a7a9cd9fc579819191' (length=33)

This seems to be mostly when a file is included, as such there is no function.