### PR TITLE
Updated ObjectDecorator setDelegate to check for interface

### DIFF
--- a/library/object/decorator/decorator.php
+++ b/library/object/decorator/decorator.php
@@ -88,7 +88,7 @@ abstract class ObjectDecorator extends ObjectDecoratorAbstract implements Object
      */
     public function setDelegate($delegate)
     {
-        if (!$delegate instanceof Object) {
+        if (!$delegate instanceof ObjectInterface) {
             throw new \InvalidArgumentException('Delegate needs to extend from Object');
         }
 


### PR DESCRIPTION
Updated ObjectDecorator setDelegate to check for interface, not concrete class. This allows for decoration of decorators.