### PR TITLE
Fixed ObjectBootstrapper::getComponents() returning paths instead of names

### DIFF
--- a/library/object/bootstrapper/bootstrapper.php
+++ b/library/object/bootstrapper/bootstrapper.php
@@ -415,7 +415,7 @@ final class ObjectBootstrapper extends Object implements ObjectBootstrapperInter
      */
     public function getComponents()
     {
-        return array_values($this->_components);
+        return array_keys($this->_components);
     }
 
     /**


### PR DESCRIPTION
Now returns array_keys instead of array_values.