### PR TITLE
Add basic auth support

### DIFF
--- a/component/users/dispatcher/authenticator/basic.php
+++ b/component/users/dispatcher/authenticator/basic.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * User: Oli Griffiths <http://github.com/oligriffiths>
+ * Date: 06/10/2014
+ * Time: 10:08
+ */
+
+namespace Nooku\Component\Users;
+
+use Nooku\Library;
+
+/**
+ * Basic Auth Authenticator
+ *
+ * @author  Oli Griffiths <http://github.com/oligriffiths>
+ * @package Nooku\Library\Dispatcher
+ */
+class DispatcherAuthenticatorBasic extends Library\DispatcherAuthenticatorAbstract
+{
+    /**
+     * Constructor.
+     *
+     * @param Library\ObjectConfig $config Configuration options
+     */
+    public function __construct(Library\ObjectConfig $config)
+    {
+        parent::__construct($config);
+
+        $action = $config->action ?: 'dispatch';
+        $this->addCommandCallback('before.'.$action, 'authenticateRequest');
+    }
+
+    /**
+     * Initializes the options for the object
+     *
+     * @config
+     * action: the default "before" action that the authenticator will respond to
+     *
+     * Called from {@link __construct()} as a first step of object instantiation.
+     *
+     * @param  ObjectConfig $config A ObjectConfig object with configuration options
+     * @return void
+     */
+    protected function _initialize(Library\ObjectConfig $config)
+    {
+        $config->append(array(
+            'action' => 'dispatch'
+        ));
+
+        parent::_initialize($config);
+    }
+
+    /**
+     * Authenticate user against users data
+     *
+     * @param Library\DispatcherContextInterface $context	A dispatcher context object
+     * @return  boolean Returns FALSE if the check failed. Otherwise TRUE.
+     */
+    public function authenticateRequest(Library\DispatcherContextInterface $context)
+    {
+        if(!$context->getUser()->isAuthentic()){
+
+            $username = $context->request->getUser();
+            $password = $context->request->getPassword();
+
+            //Only auth if username is set
+            if(!$username) return;
+
+            //Find the user
+            $user = $this->getObject('com:users.model.users')->email($username)->fetch();
+
+            //Ensure we found a user
+            if(!$user->id) throw new Library\ControllerExceptionRequestNotAuthenticated('Wrong email');
+
+            //Check user password
+            if (!$user->getPassword()->verifyPassword($password)) {
+                throw new Library\ControllerExceptionRequestNotAuthenticated('Wrong password');
+            }
+
+            //Check user enabled
+            if (!$user->enabled) {
+                throw new Library\ControllerExceptionRequestNotAuthenticated('Account disabled');
+            }
+
+            //Set user data in context
+            $data  = $this->getObject('user.provider')->load($user->id)->toArray();
+            $data['authentic'] = true;
+
+            $context->getUser()->setData($data);
+        }
+    }
+}

--- a/component/users/dispatcher/http.php
+++ b/component/users/dispatcher/http.php
@@ -30,7 +30,7 @@ class DispatcherHttp extends Library\DispatcherHttp
     protected function _initialize(Library\ObjectConfig $config)
     {
         $config->append(array(
-            'authenticators' => array('form'),
+            'authenticators' => array('basic','form'),
         ));
 
         parent::_initialize($config);

--- a/library/dispatcher/request/abstract.php
+++ b/library/dispatcher/request/abstract.php
@@ -489,6 +489,26 @@ class DispatcherRequestAbstract extends ControllerRequest implements DispatcherR
     }
 
     /**
+     * Get the request username from the request headers
+     *
+     * @return string
+     */
+    public function getUser()
+    {
+        return $this->getHeaders()->get('php-auth-user');
+    }
+
+    /**
+     * Get the request password from the request headers
+     *
+     * @return string
+     */
+    public function getPassword()
+    {
+        return $this->getHeaders()->get('php-auth-pw');
+    }
+
+    /**
      * Return the Url of the request regardless of the server
      *
      * @return  HttpUrl A HttpUrl object
@@ -751,29 +771,33 @@ class DispatcherRequestAbstract extends ControllerRequest implements DispatcherR
         {
             if(!$this->query->has('format'))
             {
-                $format = 'html';
+                $format = pathinfo($this->getUrl()->getPath(), PATHINFO_EXTENSION);
 
-                if($this->_headers->has('Accept'))
+                if(empty($format))
                 {
-                    $accept  = $this->_headers->get('Accept');
-                    $formats = $this->_parseAccept($accept);
+                    $format = 'html'; //define html default
 
-                    /**
-                     * If the browser is requested text/html serve it at all times
-                     *
-                     * @hotfix #409 : Android 2.3 requesting application/xml
-                     */
-                    if(!isset($formats['text/html']))
+                    if ($this->_headers->has('Accept'))
                     {
-                        //Get the highest quality format
-                        $mime_type = key($formats);
+                        $accept  = $this->_headers->get('Accept');
+                        $formats = $this->_parseAccept($accept);
 
-                        foreach (static::$_formats as $value => $mime_types)
+                        /**
+                         * If the browser is requested text/html serve it at all times
+                         *
+                         * @hotfix #409 : Android 2.3 requesting application/xml
+                         */
+                        if (!isset($formats['text/html']))
                         {
-                            if (in_array($mime_type, (array) $mime_types))
+                            //Get the highest quality format
+                            $mime_type = key($formats);
+
+                            foreach (static::$_formats as $value => $mime_types)
                             {
-                                $format = $value;
-                                break;
+                                if (in_array($mime_type, (array)$mime_types)) {
+                                    $format = $value;
+                                    break;
+                                }
                             }
                         }
                     }

--- a/library/dispatcher/request/interface.php
+++ b/library/dispatcher/request/interface.php
@@ -93,6 +93,20 @@ interface DispatcherRequestInterface extends ControllerRequestInterface
     public function getPort();
 
     /**
+     * Get the request username from the request headers
+     *
+     * @return string
+     */
+    public function getUser();
+
+    /**
+     * Get the request password from the request headers
+     *
+     * @return string
+     */
+    public function getPassword();
+
+    /**
      * Returns the HTTP referrer.
      *
      * 'referer' a commonly used misspelling word for 'referrer'


### PR DESCRIPTION
Basic auth support implemented as a user authenticator
Refactored the form authenticator to inherit off the basic auth user authenticator as form authentication is basically the same as basic auth, except an HTML form instead of header values
Added getUser and getPassword methods to DispatcherRequestInterface. It may be worth adding setUser and setPassword methods for consistency, thus the public interface doesn't have to worry about headers.