### PR TITLE
Implemented column existance checking on table filters

### DIFF
--- a/library/database/table/abstract.php
+++ b/library/database/table/abstract.php
@@ -105,7 +105,9 @@ abstract class DatabaseTableAbstract extends Object implements DatabaseTableInte
         if (!empty($config->filters))
         {
             foreach ($config->filters as $column => $filter) {
-                $this->getColumn($column, true)->filter = ObjectConfig::unbox($filter);
+                if($column = $this->getColumn($column, true)){
+                    $column->filter = ObjectConfig::unbox($filter);
+                }
             }
         }
 


### PR DESCRIPTION
Currently, if a filter is defined against a column that doesn't exist, an exception is thrown 

Exception 'Nooku\Library\ExceptionError' with message 'Creating default object from empty value'

This patch fixes this an silently ignore filters defined on non-existent columns