### PR TITLE
Added command mixin priority setting from config

### DIFF
--- a/library/command/mixin/mixin.php
+++ b/library/command/mixin/mixin.php
@@ -50,6 +50,9 @@ class CommandMixin extends CommandCallbackAbstract implements CommandMixinInterf
         //Create a command chain object
         $this->__command_chain = $config->command_chain;
 
+        //Set the command priority
+        $this->_priority = $config->priority;
+
         //Add the command handlers
         $handlers = (array) ObjectConfig::unbox($config->command_handlers);
 


### PR DESCRIPTION
Currently it's not possible to set the command mixin priority via config, the key is there but it's not being used. Setting this allows behaviors to take priority over commandCallback handlers as this was previously impossible.