### PR TITLE
Patched error thrown when accessing a users controller using a JSON

### DIFF
--- a/application/site/component/users/controller/permission/user.php
+++ b/application/site/component/users/controller/permission/user.php
@@ -19,7 +19,7 @@ class UsersControllerPermissionUser extends ApplicationControllerPermissionAbstr
 {
     public function canRead()
     {
-        $layout = $this->getView()->getLayout();
+        $layout = $this->getView() instanceof Library\ViewTemplate ? $this->getView()->getLayout() : null;
 
         if (in_array($layout, array('reset', 'password', 'register'))) {
             $result = true;


### PR DESCRIPTION
The permission calls getLayout() on the view. This method only exists if the view is an instance of ViewTemplate. Added condition to check for template view, else null.