### PR TITLE
Fixed object identifier config serialization

### DIFF
--- a/library/object/identifier/identifier.php
+++ b/library/object/identifier/identifier.php
@@ -140,7 +140,7 @@ class ObjectIdentifier implements ObjectIdentifierInterface
         $data['_path']       = $this->_path;
         $data['_name']       = $this->_name;
         $data['_identifier'] = $this->_identifier;
-        $data['__config']    = $this->__config;
+        $data['__config']    = ObjectConfig::unbox($this->getConfig());
 
         return serialize($data);
     }


### PR DESCRIPTION
Currently the __config variable is serialized, but this var is only initialized during instantiation, the config can be and often is modified after instantiation (see https://github.com/nooku/nooku-platform/blob/develop/library/object/manager/manager.php#L463)

This PR fixes this by ensuring the serialized version always uses the current config