### PR TITLE
Added string length check for path filter

### DIFF
--- a/library/filter/path.php
+++ b/library/filter/path.php
@@ -29,7 +29,7 @@ class FilterPath extends FilterAbstract implements FilterTraversable
     {
         $result = false;
 
-        if (is_string($value))
+        if (is_string($value) && strlen($value) >= 3)
         {
             if ($value[0] == '/' || $value[0] == '\\'
                 || (strlen($value) > 3 && ctype_alpha($value[0])


### PR DESCRIPTION
Errors are thrown if path is empty. This filter is used as part of the HTTP response to check if the response as part of checking if the response is a stream 

https://github.com/nooku/nooku-platform/blob/develop/library/dispatcher/response/abstract.php#L145

If the body is empty however, errors are raised. This happens after a delete request as the body is then empty.